### PR TITLE
Change build query parameters to force literal '&'

### DIFF
--- a/phrets.php
+++ b/phrets.php
@@ -1576,7 +1576,7 @@ class phRETS {
 		// build query string from arguments
 		$request_arguments = "";
 		if (is_array($parameters)) {
-			$request_arguments = http_build_query($parameters);
+			$request_arguments = http_build_query($parameters, '', '&');
 		}
 
 		// build entire URL if needed


### PR DESCRIPTION
On some systems php generated an html-encoded & ('&amp;') in request URLs.
This caused some RETS systems to throw miscellaneous error 20513 in response.
