### PR TITLE
Call FreeResult after there are no more rows to return in FetchRow

### DIFF
--- a/phrets.php
+++ b/phrets.php
@@ -474,6 +474,9 @@ class phRETS {
 					$this_row[$name] = $field_data[$key];
 				}
 			}
+			else {
+				$this->FreeResult($pointer_id);
+			}
 		}
 
 		return $this_row;


### PR DESCRIPTION
This pull request is to fix a memory leak with the Search function.

The Search() function doesn't return $int_result_pointer (allowing the result to be freed externally), or free the memory it's using.

So if Search is being called numerous times (example where this becomes an issue: retrieving media records for each active listing on a large feed), the internal arrays start to eat up a lot of memory.

This change calls FreeResult if $field_data is empty in FetchRow (aka there's no more data)

This is in regards to https://github.com/troydavisson/PHRETS/issues/23
