### PR TITLE
Added SetCurl function to set the cURL instance externally

### DIFF
--- a/phrets.php
+++ b/phrets.php
@@ -1394,8 +1394,11 @@ class phRETS {
 			return false;
 		}
 
-		// start cURL magic
-		$this->ch = curl_init();
+		if (!is_resource($this->ch)) {
+			// start cURL magic
+			$this->ch = curl_init();
+		}
+
 		curl_setopt($this->ch, CURLOPT_HEADERFUNCTION, array(&$this, 'read_custom_curl_headers'));
 		if ($this->debug_mode == true) {
 			// open file handler to be used by cURL debug log
@@ -1759,6 +1762,11 @@ class phRETS {
 		else {
 			return "";
 		}
+	}
+
+
+	public function SetCurl($ch) {
+		$this->ch = $ch;
 	}
 
 


### PR DESCRIPTION
This pull request is for the addition of a SetCurl function, to allow the cURL instance to be set externally and thus allow any arbitrary cURL options to be used, as well as a change to the Connect function to check if $this->ch is a resource already before initializing it.

Let me know if this looks good!

For https://github.com/troydavisson/PHRETS/issues/34
