### PR TITLE
Added POST request support with a new parameter.

### DIFF
--- a/phrets.php
+++ b/phrets.php
@@ -66,6 +66,7 @@ class phRETS {
 	private $disable_encoding_fix = false;
 	private $offset_support = false;
 	private $override_offset_protection = false;
+	private $use_post_method = false;
 
 
 
@@ -1583,9 +1584,21 @@ class phRETS {
 			$request_arguments = http_build_query($parameters, '', '&');
 		}
 
-		// build entire URL if needed
-		if (!empty($request_arguments)) {
-			$request_url = $request_url .'?'. $request_arguments;
+		// update request method on each request
+		if ($this->use_post_method) {
+			// setup cURL for POST requests
+			curl_setopt($this->ch, CURLOPT_POST, true);
+
+			// assign the POST data for this request
+			curl_setopt($this->ch, CURLOPT_POSTFIELDS, $request_arguments);
+		} else {
+			// setup cURL for GET requests
+			curl_setopt($this->ch, CURLOPT_HTTPGET, true);
+
+			// build entire URL if needed
+			if (!empty($request_arguments)) {
+				$request_url = $request_url .'?'. $request_arguments;
+			}
 		}
 
 		// build headers to pass in cURL
@@ -1799,6 +1812,9 @@ class phRETS {
 				break;
 			case "override_offset_protection":
 				$this->override_offset_protection = $value;
+				break;
+			case "use_post_method":
+				$this->use_post_method = $value;
 				break;
 			default:
 				return false;


### PR DESCRIPTION
This pull request adds support for using POST requests, instead of GET requests.  The functionality is enabled using a new boolean parameter `use_post_method`.  When `use_post_method` is set to true, cURL will issue POST requests, otherwise cURL will issue GET requests.  The default is false (GET).

Additionally, the functionality has been implemented in such a way that the value of the parameter will be taken into account on each request, not just during `Connect()`.  This means, throughout the life of a session, some requests can be GETs, and some can be POSTs.

One use case for using POST requests is to allow for exceptionally long RETS queries.  In this case, the RETS query can generate a query string that is too long for GET requests, and a POST request must be used.
