### PR TITLE
Increase compat between Limit and offset_support

### DIFF
--- a/phrets.php
+++ b/phrets.php
@@ -614,7 +614,7 @@ class phRETS {
 				unset($xml);
 			}
 
-			if ($this->IsMaxrowsReached($this->int_result_pointer) && $this->offset_support) {
+			if ($this->IsMaxrowsReached($this->int_result_pointer) && $this->offset_support && ($search_arguments['Limit'] > count($this->search_data[$this->int_result_pointer]['data']))) {
 				$continue_searching = true;
 				$search_arguments['Offset'] = $this->NumRows($this->int_result_pointer) + 1;
 			}


### PR DESCRIPTION
This is probably a provider specific issue but it shouldn't hurt when interacting with
other providers. With the specific provider I am interacting with there seems to be
an incompatability between the Limit option and the offset_support functionality to
automatically page a query.

When both are enabled (i.e. ['Limit' => 1] and offset_support is true) we end up
throwing an error due to submitting more than 300 queries. The provider is coming
back with IsMaxrowsReached indicating there are more rows even though we got
the one record we requested. I think this is basically causing the page size to be
equal to the Limit size. In my case of 'Limit' => 1 it is making a request per record.

This change accounts for this by counting the total number of records we have
received and not continuing if that number exceeds the limit.
