### PR TITLE
Fix RETS 1.5 missing headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": ">=4.0,<6.0",
+    "guzzlehttp/guzzle": ">=6.0",
     "illuminate/container": ">=4.2.0",
     "illuminate/support": ">=4.2.0",
     "league/csv": ">=6.0"
@@ -27,7 +27,7 @@
     "phpunit/phpunit": "4.1.*",
     "psr/log": "1.*",
     "monolog/monolog": "1.10.*",
-    "gsaulmon/guzzlerecorder": "dev-master"
+    "gsaulmon/guzzlerecorder": "2.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -1,6 +1,7 @@
 <?php namespace PHRETS\Http;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface;
 
 class Client
 {
@@ -9,16 +10,16 @@ class Client
     /**
      * @return GuzzleClient
      */
-    public static function make()
+    public static function make($options = [])
     {
         if (!self::$client) {
-            self::$client = new GuzzleClient;
+            self::$client = new GuzzleClient($options);
         }
 
         return self::$client;
     }
 
-    public static function set(GuzzleClient $client)
+    public static function set(ClientInterface $client)
     {
         self::$client = $client;
     }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,0 +1,34 @@
+<?php namespace PHRETS\Http;
+
+use Psr\Http\Message\ResponseInterface;
+
+class Response
+{
+	protected $response = null;
+
+	public function __construct(ResponseInterface $response)
+	{
+		$this->response = $response;
+	}
+
+	public function xml()
+	{
+		return new \SimpleXMLElement((string) $this->response->getBody());
+	}
+
+	public function __call($method, $args = [])
+	{
+		return call_user_func_array([$this->response, $method], $args);
+	}
+
+	public function getHeader($name)
+	{
+		$headers = $this->response->getHeader($name);
+		
+		if ($headers) {
+			return implode('; ', $headers);
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/Parsers/GetMetadata/LookupType.php
+++ b/src/Parsers/GetMetadata/LookupType.php
@@ -1,12 +1,12 @@
 <?php namespace PHRETS\Parsers\GetMetadata;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use Illuminate\Support\Collection;
 use PHRETS\Session;
 
 class LookupType extends Base
 {
-    public function parse(Session $rets, ResponseInterface $response)
+    public function parse(Session $rets, Response $response)
     {
         $xml = $response->xml();
 

--- a/src/Parsers/GetMetadata/Object.php
+++ b/src/Parsers/GetMetadata/Object.php
@@ -1,12 +1,12 @@
 <?php namespace PHRETS\Parsers\GetMetadata;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use Illuminate\Support\Collection;
 use PHRETS\Session;
 
 class Object extends Base
 {
-    public function parse(Session $rets, ResponseInterface $response)
+    public function parse(Session $rets, Response $response)
     {
         $xml = $response->xml();
 

--- a/src/Parsers/GetMetadata/Resource.php
+++ b/src/Parsers/GetMetadata/Resource.php
@@ -1,12 +1,12 @@
 <?php namespace PHRETS\Parsers\GetMetadata;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use Illuminate\Support\Collection;
 use PHRETS\Session;
 
 class Resource extends Base
 {
-    public function parse(Session $rets, ResponseInterface $response)
+    public function parse(Session $rets, Response $response)
     {
         $xml = $response->xml();
 

--- a/src/Parsers/GetMetadata/ResourceClass.php
+++ b/src/Parsers/GetMetadata/ResourceClass.php
@@ -1,12 +1,12 @@
 <?php namespace PHRETS\Parsers\GetMetadata;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use Illuminate\Support\Collection;
 use PHRETS\Session;
 
 class ResourceClass extends Base
 {
-    public function parse(Session $rets, ResponseInterface $response)
+    public function parse(Session $rets, Response $response)
     {
         $xml = $response->xml();
 

--- a/src/Parsers/GetMetadata/System.php
+++ b/src/Parsers/GetMetadata/System.php
@@ -1,11 +1,11 @@
 <?php namespace PHRETS\Parsers\GetMetadata;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use PHRETS\Session;
 
 class System extends Base
 {
-    public function parse(Session $rets, ResponseInterface $response)
+    public function parse(Session $rets, Response $response)
     {
         $xml = $response->xml();
         $base = $xml->METADATA->{'METADATA-SYSTEM'};

--- a/src/Parsers/GetMetadata/Table.php
+++ b/src/Parsers/GetMetadata/Table.php
@@ -1,12 +1,12 @@
 <?php namespace PHRETS\Parsers\GetMetadata;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use Illuminate\Support\Collection;
 use PHRETS\Session;
 
 class Table extends Base
 {
-    public function parse(Session $rets, ResponseInterface $response, $keyed_by)
+    public function parse(Session $rets, Response $response, $keyed_by)
     {
         $xml = $response->xml();
 

--- a/src/Parsers/GetObject/Multiple.php
+++ b/src/Parsers/GetObject/Multiple.php
@@ -1,15 +1,12 @@
 <?php namespace PHRETS\Parsers\GetObject;
 
-use GuzzleHttp\Message\MessageParser;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Response;
+use PHRETS\Http\Response as PHRETSResponse;
 use Illuminate\Support\Collection;
-use PHRETS\Models\Object;
 
 class Multiple
 {
-    public function parse(ResponseInterface $response)
+    public function parse(PHRETSResponse $response)
     {
         $collection = new Collection;
 
@@ -26,7 +23,11 @@ class Multiple
             $boundary = $matches[1];
         } else {
             preg_match('/boundary\=(.*?)(\s|$|\;)/', $response->getHeader('Content-Type'), $matches);
-            $boundary = $matches[1];
+            if (isset($matches[1])) {
+                $boundary = $matches[1];
+            } else {
+                $boundary = null;
+            }
         }
         // strip quotes off of the boundary
         $boundary = preg_replace('/^\"(.*?)\"$/', '\1', $boundary);
@@ -43,16 +44,15 @@ class Multiple
         // take off anything after the last boundary (the epilogue)
         array_pop($multi_parts);
 
-        $message_parser = new MessageParser;
         $parser = new Single;
 
         // go through each part of the multipart message
         foreach ($multi_parts as $part) {
             // get Guzzle to parse this multipart section as if it's a whole HTTP message
-            $parts = $message_parser->parseResponse("HTTP/1.1 200 OK\r\n" . $part);
+            $parts = \GuzzleHttp\Psr7\parse_response("HTTP/1.1 200 OK\r\n" . $part);
 
             // now throw this single faked message through the Single GetObject response parser
-            $single = new Response($parts['code'], $parts['headers'], Stream::factory($parts['body']));
+            $single = new PHRETSResponse(new Response($parts->getStatusCode(), $parts->getHeaders(), (string)$parts->getBody()));
             $obj = $parser->parse($single);
 
             // add information about this multipart to the returned collection

--- a/src/Parsers/GetObject/Single.php
+++ b/src/Parsers/GetObject/Single.php
@@ -1,12 +1,12 @@
 <?php namespace PHRETS\Parsers\GetObject;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use PHRETS\Models\Object;
 use PHRETS\Models\RETSError;
 
 class Single
 {
-    public function parse(ResponseInterface $response)
+    public function parse(Response $response)
     {
         $headers = $response->getHeaders();
 
@@ -23,18 +23,25 @@ class Single
 
         if ($this->isError($response)) {
             $xml = $response->xml();
+            
             $error = new RETSError;
-            $error->setCode((string)\array_get($xml, 'ReplyCode'));
-            $error->setMessage((string)\array_get($xml, 'ReplyText'));
+            
+            if (isset($xml['ReplyCode'])) {
+                $error->setCode((string) $xml['ReplyCode']);
+            }
+            if (isset($xml['ReplyText'])) {
+                $error->setMessage((string) $xml['ReplyText']);
+            }
+            
             $obj->setError($error);
         }
 
         return $obj;
     }
 
-    protected function isError(ResponseInterface $response)
+    protected function isError(Response $response)
     {
-        if (\array_get($response->getHeaders(), 'RETS-Error', [null])[0] == 1) {
+        if ($response->getHeader('RETS-Error') == 1) {
             return true;
         }
 

--- a/src/Parsers/Search/OneX.php
+++ b/src/Parsers/Search/OneX.php
@@ -1,13 +1,13 @@
 <?php namespace PHRETS\Parsers\Search;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use PHRETS\Models\Search\Record;
 use PHRETS\Models\Search\Results;
 use PHRETS\Session;
 
 class OneX
 {
-    public function parse(Session $rets, ResponseInterface $response, $parameters)
+    public function parse(Session $rets, Response $response, $parameters)
     {
         $xml = $response->xml();
 

--- a/src/Parsers/Search/RecursiveOneX.php
+++ b/src/Parsers/Search/RecursiveOneX.php
@@ -1,13 +1,13 @@
 <?php namespace PHRETS\Parsers\Search;
 
-use GuzzleHttp\Message\ResponseInterface;
+use PHRETS\Http\Response;
 use PHRETS\Exceptions\AutomaticPaginationError;
 use PHRETS\Models\Search\Results;
 use PHRETS\Session;
 
 class RecursiveOneX
 {
-    public function parse(Session $rets, ResponseInterface $response, $parameters)
+    public function parse(Session $rets, Response $response, $parameters)
     {
         // we're given the first response automatically, so parse this and start the recursion
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -332,7 +332,8 @@ class Session
         // user-agent authentication
         if ($this->configuration->getUserAgentPassword()) {
             $ua_digest = $this->configuration->userAgentDigestHash($this);
-            $options['headers'] = ['RETS-UA-Authorization' => 'Digest ' . $ua_digest];
+            if(!empty($options['headers'])) $options['headers'] = array_merge($options['headers'], ['RETS-UA-Authorization' => 'Digest ' . $ua_digest]);
+            else $options['headers'] = ['RETS-UA-Authorization' => 'Digest ' . $ua_digest];
         }
 
         $options = array_merge($options, ['cookies' => $this->cookie_jar]);
@@ -366,7 +367,7 @@ class Session
                 }
             }
         }
-        
+
 
         if ($response->getHeader('Content-Type') == 'text/xml' and $capability != 'GetObject') {
             $xml = $response->xml();

--- a/src/Session.php
+++ b/src/Session.php
@@ -34,34 +34,12 @@ class Session
         // save the configuration along with this session
         $this->configuration = $configuration;
 
+        $defaults = [];
+
         // start up our Guzzle HTTP client
-        $this->client = PHRETSClient::make();
+        $this->client = PHRETSClient::make($defaults);
 
         $this->cookie_jar = new CookieJar;
-
-        // set the authentication as defaults to use for the entire client
-        $this->client->setDefaultOption(
-                'auth',
-                [
-                        $configuration->getUsername(),
-                        $configuration->getPassword(),
-                        $configuration->getHttpAuthenticationMethod()
-                ]
-        );
-        $this->client->setDefaultOption(
-                'headers',
-                [
-                    'User-Agent' => $configuration->getUserAgent(),
-                    'RETS-Version' => $configuration->getRetsVersion()->asHeader(),
-                    'Accept-Encoding' => 'gzip',
-                    'Accept' => '*/*',
-                ]
-        );
-
-        // disable following 'Location' header (redirects) automatically
-        if ($this->configuration->readOption('disable_follow_location')) {
-            $this->client->setDefaultOption('allow_redirects', false);
-        }
 
         // start up the Capabilities tracker and add Login as the first one
         $this->capabilities = new Capabilities;
@@ -93,7 +71,8 @@ class Session
         $response = $this->request('Login');
 
         $parser = $this->grab('parser.login');
-        $parser->parse($response->xml()->{'RETS-RESPONSE'}->__toString());
+        $xml = new \SimpleXMLElement((string)$response->getBody());
+        $parser->parse($xml->{'RETS-RESPONSE'}->__toString());
 
         foreach ($parser->getCapabilities() as $k => $v) {
             $this->capabilities->add($k, $v);
@@ -329,17 +308,31 @@ class Session
             throw new CapabilityUnavailable("'{$capability}' tried but no valid endpoint was found.  Did you forget to Login()?");
         }
 
-        if (!array_key_exists('headers', $options)) {
-            $options['headers'] = [];
+        $defaults = [
+            'auth' => [
+                $this->configuration->getUsername(),
+                $this->configuration->getPassword(),
+                $this->configuration->getHttpAuthenticationMethod()
+            ],
+            'headers' => [
+                'User-Agent' => $this->configuration->getUserAgent(),
+                'RETS-Version' => $this->configuration->getRetsVersion()->asHeader(),
+                'Accept-Encoding' => 'gzip',
+                'Accept' => '*/*',
+            ],
+        ];
+
+        // disable following 'Location' header (redirects) automatically
+        if ($this->configuration->readOption('disable_follow_location')) {
+            $defaults['allow_redirects'] = false;
         }
 
-        // Guzzle 5 changed the order that headers are added to the request, so we'll do this manually
-        $options['headers'] = array_merge($this->client->getDefaultOption('headers'), $options['headers']);
+        $options = array_merge($defaults, $options);
 
         // user-agent authentication
         if ($this->configuration->getUserAgentPassword()) {
             $ua_digest = $this->configuration->userAgentDigestHash($this);
-            $options['headers'] = array_merge($options['headers'], ['RETS-UA-Authorization' => 'Digest ' . $ua_digest]);
+            $options['headers'] = ['RETS-UA-Authorization' => 'Digest ' . $ua_digest];
         }
 
         $options = array_merge($options, ['cookies' => $this->cookie_jar]);
@@ -356,19 +349,24 @@ class Session
         if ($this->configuration->readOption('use_post_method')) {
             $this->debug('Using POST method per use_post_method option');
             $query = (array_key_exists('query', $options)) ? $options['query'] : null;
-            $response = $this->client->post($url, array_merge($options, ['body' => $query]));
+            $response = $this->client->request('POST', $url, array_merge($options, ['body' => $query]));
         } else {
-            $response = $this->client->get($url, $options);
+            $response = $this->client->request('GET', $url, $options);
         }
+
+        $response = new \PHRETS\Http\Response($response);
 
         $this->last_response = $response;
 
-        $cookie = $response->getHeader('Set-Cookie');
-        if ($cookie) {
-            if (preg_match('/RETS-Session-ID\=(.*?)(\;|\s+|$)/', $cookie, $matches)) {
-                $this->rets_session_id = $matches[1];
+        if ($response->getHeader('Set-Cookie')) {
+            $cookie = $response->getHeader('Set-Cookie');
+            if ($cookie) {
+                if (preg_match('/RETS-Session-ID\=(.*?)(\;|\s+|$)/', $cookie, $matches)) {
+                    $this->rets_session_id = $matches[1];
+                }
             }
         }
+        
 
         if ($response->getHeader('Content-Type') == 'text/xml' and $capability != 'GetObject') {
             $xml = $response->xml();

--- a/tests/Integration/BaseIntegration.php
+++ b/tests/Integration/BaseIntegration.php
@@ -12,14 +12,6 @@ class BaseIntegration extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $client = new GuzzleHttp\Client;
-        $watcher = new Gsaulmon\GuzzleRecorder\GuzzleRecorder(__DIR__ . '/Fixtures/Http');
-        $watcher->addIgnoredHeader('Accept');
-        $watcher->addIgnoredHeader('Cookie');
-
-        $client->getEmitter()->attach($watcher);
-        \PHRETS\Http\Client::set($client);
-
         $config = new \PHRETS\Configuration;
         $config->setLoginUrl('http://retsgw.flexmls.com/rets2_1/Login')
                 ->setUsername(getenv('PHRETS_TESTING_USERNAME'))
@@ -27,6 +19,19 @@ class BaseIntegration extends PHPUnit_Framework_TestCase
                 ->setRetsVersion('1.7.2');
 
         $this->session = new PHRETS\Session($config);
+        $client = $this->session->getClient();
+
+        $defaults = $client->getConfig();
+        $new_client = new GuzzleHttp\Client($defaults);
+
+        PHRETS\Http\Client::set($new_client);
+
+        $watcher = new Gsaulmon\GuzzleRecorder\GuzzleRecorder(__DIR__ . '/Fixtures/Http');
+        $watcher->addIgnoredHeader('Accept');
+        $watcher->addIgnoredHeader('Cookie');
+
+        $watcher->attach_to($new_client);
+
         $this->session->Login();
     }
 }

--- a/tests/Parsers/GetObject/MultipleTest.php
+++ b/tests/Parsers/GetObject/MultipleTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Response;
 use PHRETS\Parsers\GetObject\Multiple;
+use PHRETS\Http\Response as PHRETSResponse;
 
 class MultipleTest extends PHPUnit_Framework_TestCase
 {
@@ -36,7 +36,7 @@ class MultipleTest extends PHPUnit_Framework_TestCase
         $body = json_decode(file_get_contents('tests/Fixtures/GetObject/Multiple1.txt', true));
 
         $parser = new Multiple;
-        $collection = $parser->parse(new Response(200, $headers, Stream::factory($body)));
+        $collection = $parser->parse(new PHRETSResponse(new Response(200, $headers, $body)));
 
         $this->assertSame(5, $collection->count());
 
@@ -50,7 +50,7 @@ class MultipleTest extends PHPUnit_Framework_TestCase
     public function it_handles_empty_bodies()
     {
         $parser = new Multiple;
-        $collection = $parser->parse(new Response(200, [], null));
+        $collection = $parser->parse(new PHRETSResponse(new Response(200, [], null)));
 
         $this->assertInstanceOf('Illuminate\\Support\\Collection', $collection);
     }
@@ -84,7 +84,7 @@ class MultipleTest extends PHPUnit_Framework_TestCase
         $body = json_decode(file_get_contents('tests/Fixtures/GetObject/Multiple1.txt', true));
 
         $parser = new Multiple;
-        $collection = $parser->parse(new Response(200, $headers, Stream::factory($body)));
+        $collection = $parser->parse(new PHRETSResponse(new Response(200, $headers, $body)));
 
         $this->assertSame(5, $collection->count());
 

--- a/tests/Parsers/GetObject/SingleTest.php
+++ b/tests/Parsers/GetObject/SingleTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Response;
+use PHRETS\Http\Response as PHRETSResponse;
 use PHRETS\Parsers\GetObject\Single;
 
 class SingleTest extends PHPUnit_Framework_TestCase {
@@ -10,7 +10,7 @@ class SingleTest extends PHPUnit_Framework_TestCase {
     public function it_understands_the_basics()
     {
         $parser = new Single;
-        $single = new Response(200, ['Content-Type' => 'text/plain'], Stream::factory('Test'));
+        $single = new PHRETSResponse(new Response(200, ['Content-Type' => 'text/plain'], 'Test'));
         $obj = $parser->parse($single);
 
         $this->assertSame('Test', $obj->getContent());
@@ -24,7 +24,7 @@ class SingleTest extends PHPUnit_Framework_TestCase {
         Valid Classes are: A B C E F G H I
         </RETS>';
         $parser = new Single;
-        $single = new Response(200, ['Content-Type' => 'text/xml'], Stream::factory($error));
+        $single = new PHRETSResponse(new Response(200, ['Content-Type' => 'text/xml'], $error));
         $obj = $parser->parse($single);
 
         $this->assertTrue($obj->isError());
@@ -39,7 +39,7 @@ class SingleTest extends PHPUnit_Framework_TestCase {
         Valid Classes are: A B C E F G H I
         </RETS>';
         $parser = new Single;
-        $single = new Response(200, ['Content-Type' => 'text/plain', 'RETS-Error' => '1'], Stream::factory($error));
+        $single = new PHRETSResponse(new Response(200, ['Content-Type' => 'text/plain', 'RETS-Error' => '1'], $error));
         $obj = $parser->parse($single);
 
         $this->assertTrue($obj->isError());

--- a/tests/Parsers/Search/OneXTest.php
+++ b/tests/Parsers/Search/OneXTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Response;
+use PHRETS\Http\Response as PHRETSResponse;
 use PHRETS\Configuration;
 use PHRETS\Parsers\Search\OneX;
 use PHRETS\Session;
@@ -37,7 +37,7 @@ class OneXTest extends PHPUnit_Framework_TestCase
         $c->setLoginUrl('http://www.reso.org/login');
 
         $s = new Session($c);
-        $this->results = $parser->parse($s, new Response(200, [], Stream::factory($data)), $parameters);
+        $this->results = $parser->parse($s, new PHRETSResponse(new Response(200, [], $data)), $parameters);
     }
 
     /** @test **/


### PR DESCRIPTION
@troydavisson The branch is working nicely except with older RETS 1.5 MLS (interealty) that need the Accept _/_ header. So I just pulled a fix I currently use.
Regards.
