### PR TITLE
Node name does not exist: use System instead of SYSTEM

### DIFF
--- a/src/Parsers/GetMetadata/System.php
+++ b/src/Parsers/GetMetadata/System.php
@@ -26,19 +26,19 @@ class System extends Base
                 $metadata->setSystemDescription((string)$base->System->SystemDescription);
             }
         } else {
-            if (isset($base->SYSTEM->attributes()->SystemID)) {
+            if (isset($base->System->attributes()->SystemID)) {
                 $metadata->setSystemId((string)$base->SYSTEM->attributes()->SystemID);
             }
-            if (isset($base->SYSTEM->attributes()->SystemDescription)) {
-                $metadata->setSystemDescription((string)$base->SYSTEM->attributes()->SystemDescription);
+            if (isset($base->System->attributes()->SystemDescription)) {
+                $metadata->setSystemDescription((string)$base->System->attributes()->SystemDescription);
             }
-            if (isset($base->SYSTEM->attributes()->TimeZoneOffset)) {
-                $metadata->setTimezoneOffset((string)$base->SYSTEM->attributes()->TimeZoneOffset);
+            if (isset($base->System->attributes()->TimeZoneOffset)) {
+                $metadata->setTimezoneOffset((string)$base->System->attributes()->TimeZoneOffset);
             }
         }
 
-        if (isset($base->SYSTEM->Comments)) {
-            $metadata->setComments((string)$base->SYSTEM->Comments);
+        if (isset($base->System->Comments)) {
+            $metadata->setComments((string)$base->System->Comments);
         }
         if (isset($base->attributes()->Version)) {
             $metadata->setVersion((string)$xml->METADATA->{'METADATA-SYSTEM'}->attributes()->Version);


### PR DESCRIPTION
Running version 2.4 on PHP 7.1.4, was getting an error message:

```
[2017-07-07 18:23:35] local.ERROR: ErrorException: PHRETS\Parsers\GetMetadata\System::parse(): Node no longer exists in /Users/aaron/repos/c21redwood/c21-backoffice/vendor/troydavisson/phrets/src/Parsers/GetMetadata/System.php:29
Stack trace:
#0 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/troydavisson/phrets/src/Parsers/GetMetadata/System.php(29): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'PHRETS\\Parsers\\...', '/Users/aaron/re...', 29, Array)
#1 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/troydavisson/phrets/src/Session.php(244): PHRETS\Parsers\GetMetadata\System->parse(Object(PHRETS\Session), Object(PHRETS\Http\Response), NULL)
#2 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/troydavisson/phrets/src/Session.php(153): PHRETS\Session->MakeMetadataRequest('METADATA-SYSTEM', 0, Object(PHRETS\Parsers\GetMetadata\System))
#3 /Users/aaron/repos/c21redwood/c21-backoffice/app/Console/Commands/RetsLogin.php(55): PHRETS\Session->GetSystemMetadata()
#4 [internal function]: App\Console\Commands\RetsLogin->handle()
#5 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(29): call_user_func_array(Array, Array)
#6 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(87): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#7 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(31): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#8 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Container/Container.php(539): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#9 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Console/Command.php(182): Illuminate\Container\Container->call(Array)
#10 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/symfony/console/Command/Command.php(264): Illuminate\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#11 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Console/Command.php(167): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#12 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/symfony/console/Application.php(869): Illuminate\Console\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/symfony/console/Application.php(223): Symfony\Component\Console\Application->doRunCommand(Object(App\Console\Commands\RetsLogin), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/symfony/console/Application.php(130): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /Users/aaron/repos/c21redwood/c21-backoffice/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(122): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /Users/aaron/repos/c21redwood/c21-backoffice/artisan(35): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 {main}  
```

Renaming the property `SYSTEM` to `System` fixes the problem.