### PR TITLE
Server died cause of no more disk space (temp session in /tmp do not get removed)

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,6 +20,7 @@ class Configuration
     protected $http_authentication = 'digest';
     /** @var \PHRETS\Strategies\Strategy */
     protected $strategy;
+    protected $sessionTempDir = null;
     protected $options = [];
 
     public function __construct()
@@ -133,6 +134,24 @@ class Configuration
     {
         $this->username = $username;
         return $this;
+    }
+
+    /**
+     * @param string $username
+     * @return $this
+     */
+    public function setSessionTempDir($sessionTempDir)
+    {
+        $this->sessionTempdDir = $sessionTempDir;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSessionTempDir()
+    {
+        return $this->sessionTempDir;
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -339,6 +339,8 @@ class Session
 
         $response = new \PHRETS\Http\Response($response);
 
+        $this->removeSessionCookieFile($options);
+
         $this->last_response = $response;
 
         if ($response->getHeader('Set-Cookie')) {
@@ -349,7 +351,7 @@ class Session
                 }
             }
         }
-        
+
         if (preg_match('/text\/xml/', $response->getHeader('Content-Type')) and $capability != 'GetObject') {
             $parser = $this->grab(Strategy::PARSER_XML);
             $xml = $parser->parse($response);
@@ -481,7 +483,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => tempnam($this->configuration->getSessionTempDir(), 'phrets') ]
         ];
 
         // disable following 'Location' header (redirects) automatically
@@ -490,6 +492,21 @@ class Session
         }
 
         return $defaults;
+    }
+
+    /**
+     * If the session cookie file have beend created, we will remove it.
+     *
+     * @param array $options Assoc array that came from the method getDefaultOptions.
+     *
+     * @return void
+     */
+    private function removeSessionCookieFile(array $options)
+    {
+        $tmpFile = $options['curl'][CURLOPT_COOKIEFILE];
+        if (file_exists($tmpFile)) {
+            unlink($tmpFile);
+        }
     }
 
     public function setParser($parser_name, $parser_object)


### PR DESCRIPTION
- I've added code to remove the temporary session file that get create
  on each rets request.  This file is not used anymore once we get the
  gets server response and it didn't get removed.

- /tmp folder was hardcoded, I've added a way to configure it into the
  configuration of the PHRets.  By default it will be null.