### PR TITLE
http_authentication with server using rets-version 1.8 (401 Unauthorized)

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -259,7 +259,7 @@ class Configuration
      */
     public function setHttpAuthenticationMethod($auth_method)
     {
-        if ($auth_method && !in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
+        if (!in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
             throw new \InvalidArgumentException("Given authentication method is invalid.  Must be 'basic' or 'digest'");
         }
         $this->http_authentication = $auth_method;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -259,7 +259,7 @@ class Configuration
      */
     public function setHttpAuthenticationMethod($auth_method)
     {
-        if (!in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
+        if ($auth_method && !in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
             throw new \InvalidArgumentException("Given authentication method is invalid.  Must be 'basic' or 'digest'");
         }
         $this->http_authentication = $auth_method;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,6 +20,7 @@ class Configuration
     protected $http_authentication = 'digest';
     /** @var \PHRETS\Strategies\Strategy */
     protected $strategy;
+    protected $sessionTempDir = null;
     protected $options = [];
 
     public function __construct()
@@ -133,6 +134,24 @@ class Configuration
     {
         $this->username = $username;
         return $this;
+    }
+
+    /**
+     * @param string $username
+     * @return $this
+     */
+    public function setSessionTempDir($sessionTempDir)
+    {
+        $this->sessionTempdDir = $sessionTempDir;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSessionTempDir()
+    {
+        return $this->sessionTempDir;
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -339,6 +339,8 @@ class Session
 
         $response = new \PHRETS\Http\Response($response);
 
+        $this->removeSessionCookieFile($options);
+
         $this->last_response = $response;
 
         if ($response->getHeader('Set-Cookie')) {
@@ -349,7 +351,7 @@ class Session
                 }
             }
         }
-        
+
         if (preg_match('/text\/xml/', $response->getHeader('Content-Type')) and $capability != 'GetObject') {
             $parser = $this->grab(Strategy::PARSER_XML);
             $xml = $parser->parse($response);
@@ -481,7 +483,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => tempnam($this->configuration->getSessionTempDir(), 'phrets') ]
         ];
 
         // disable following 'Location' header (redirects) automatically
@@ -490,6 +492,21 @@ class Session
         }
 
         return $defaults;
+    }
+
+    /**
+     * If the session cookie file have beend created, we will remove it.
+     *
+     * @param array $options Assoc array that came from the method getDefaultOptions.
+     *
+     * @return void
+     */
+    private function removeSessionCookieFile(array $options)
+    {
+        $tmpFile = $options['curl'][CURLOPT_COOKIEFILE];
+        if (file_exists($tmpFile)) {
+            unlink($tmpFile);
+        }
     }
 
     public function setParser($parser_name, $parser_object)


### PR DESCRIPTION
Some rets service, like the one from bridge-rets.mlspin.com do not work if you pass a value (basic or digest) into the http_authentication.  I've modify the code to be able to pass http_authentication = null when we set the config.