### PR TITLE
PHP7.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
 before_script: composer install
 env:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,9 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <php>
+        <env name="PHRETS_TESTING_USERNAME" value="fake"/>
+        <env name="PHRETS_TESTING_PASSWORD" value="fake"/>
+    </php>
 </phpunit>

--- a/src/Models/BaseObject.php
+++ b/src/Models/BaseObject.php
@@ -1,6 +1,6 @@
 <?php namespace PHRETS\Models;
 
-class Object
+class BaseObject
 {
     protected $content_type;
     protected $content_id;

--- a/src/Models/Metadata/BaseObject.php
+++ b/src/Models/Metadata/BaseObject.php
@@ -15,7 +15,7 @@
  * @method string getDate
  * @method string getResource
  */
-class Object extends Base
+class BaseObject extends Base
 {
     protected $elements = [
         'MetadataEntryID',

--- a/src/Models/Metadata/Resource.php
+++ b/src/Models/Metadata/Resource.php
@@ -72,7 +72,7 @@ class Resource extends Base
     }
 
     /**
-     * @return \Illuminate\Support\Collection|\PHRETS\Models\Metadata\Object[]
+     * @return \Illuminate\Support\Collection|\PHRETS\Models\Metadata\BaseObject[]
      */
     public function getObject()
     {

--- a/src/Parsers/GetMetadata/BaseObject.php
+++ b/src/Parsers/GetMetadata/BaseObject.php
@@ -4,7 +4,7 @@ use PHRETS\Http\Response;
 use Illuminate\Support\Collection;
 use PHRETS\Session;
 
-class Object extends Base
+class BaseObject extends Base
 {
     public function parse(Session $rets, Response $response)
     {
@@ -17,7 +17,7 @@ class Object extends Base
         if ($xml->METADATA) {
             if ($xml->METADATA->{'METADATA-OBJECT'}) {
                 foreach ($xml->METADATA->{'METADATA-OBJECT'}->Object as $key => $value) {
-                    $metadata = new \PHRETS\Models\Metadata\Object;
+                    $metadata = new \PHRETS\Models\Metadata\BaseObject;
                     $metadata->setSession($rets);
                     $obj = $this->loadFromXml($metadata, $value, $xml->METADATA->{'METADATA-OBJECT'});
                     $collection->put($obj->getObjectType(), $obj);

--- a/src/Parsers/GetObject/Single.php
+++ b/src/Parsers/GetObject/Single.php
@@ -1,7 +1,7 @@
 <?php namespace PHRETS\Parsers\GetObject;
 
 use PHRETS\Http\Response;
-use PHRETS\Models\Object;
+use PHRETS\Models\BaseObject;
 use PHRETS\Models\RETSError;
 
 class Single
@@ -10,7 +10,7 @@ class Single
     {
         $headers = $response->getHeaders();
 
-        $obj = new Object;
+        $obj = new BaseObject;
         $obj->setContent(($response->getBody()) ? $response->getBody()->__toString() : null);
         $obj->setContentDescription(\array_get($headers, 'Content-Description', [null])[0]);
         $obj->setContentSubDescription(\array_get($headers, 'Content-Sub-Description', [null])[0]);

--- a/src/Session.php
+++ b/src/Session.php
@@ -97,7 +97,7 @@ class Session
      * @param $type
      * @param $content_id
      * @param int $location
-     * @return \PHRETS\Models\Object
+     * @return \PHRETS\Models\BaseObject
      */
     public function GetPreferredObject($resource, $type, $content_id, $location = 0)
     {

--- a/src/Strategies/StandardStrategy.php
+++ b/src/Strategies/StandardStrategy.php
@@ -20,7 +20,7 @@ class StandardStrategy implements Strategy
         Strategy::PARSER_METADATA_RESOURCE => \PHRETS\Parsers\GetMetadata\Resource::class,
         Strategy::PARSER_METADATA_CLASS => \PHRETS\Parsers\GetMetadata\ResourceClass::class,
         Strategy::PARSER_METADATA_TABLE => \PHRETS\Parsers\GetMetadata\Table::class,
-        Strategy::PARSER_METADATA_OBJECT => \PHRETS\Parsers\GetMetadata\Object::class,
+        Strategy::PARSER_METADATA_OBJECT => \PHRETS\Parsers\GetMetadata\BaseObject::class,
         Strategy::PARSER_METADATA_LOOKUPTYPE => \PHRETS\Parsers\GetMetadata\LookupType::class,
         Strategy::PARSER_XML => \PHRETS\Parsers\XML::class,
     ];

--- a/tests/Integration/GetMetadataIntegrationTest.php
+++ b/tests/Integration/GetMetadataIntegrationTest.php
@@ -192,7 +192,7 @@ class GetMetadataIntegrationTest extends BaseIntegration
     public function it_gets_keyed_object_metadata()
     {
         $object_types = $this->session->GetObjectMetadata('Property');
-        $this->assertInstanceOf('\PHRETS\Models\Metadata\Object', $object_types['Photo']);
+        $this->assertInstanceOf('\PHRETS\Models\Metadata\BaseObject', $object_types['Photo']);
     }
 
     /**

--- a/tests/Integration/GetObjectIntegrationTest.php
+++ b/tests/Integration/GetObjectIntegrationTest.php
@@ -20,7 +20,7 @@ class GetObjectIntegrationTest extends BaseIntegration
         $primary = $objects->first();
 
         $object = $this->session->GetPreferredObject('Property', 'Photo', '00-1669', 1);
-        $this->assertTrue($object instanceof \PHRETS\Models\Object);
+        $this->assertTrue($object instanceof \PHRETS\Models\BaseObject);
         $this->assertEquals($primary, $object);
     }
 
@@ -37,7 +37,7 @@ class GetObjectIntegrationTest extends BaseIntegration
         $object = $this->session->GetObject('Property', 'Photo', 'URLS-WITH-XML', '*', 1);
 
         $this->assertCount(1, $object);
-        /** @var \PHRETS\Models\Object $first */
+        /** @var \PHRETS\Models\BaseObject $first */
         $first = $object->first();
         $this->assertFalse($first->isError());
         $this->assertSame('http://someurl', $first->getLocation());

--- a/tests/Models/ObjectTest.php
+++ b/tests/Models/ObjectTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use PHRETS\Models\Object;
+use PHRETS\Models\BaseObject;
 
 class ObjectTest extends PHPUnit_Framework_TestCase {
 
     /** @test **/
     public function it_holds()
     {
-        $o = new Object;
+        $o = new BaseObject;
         $o->setContent('Test Content');
 
         $this->assertSame('Test Content', $o->getContent());
@@ -16,7 +16,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase {
     /** @test **/
     public function it_returns_a_size()
     {
-        $o = new Object;
+        $o = new BaseObject;
         $o->setContent('Hello');
 
         $this->assertSame(5, $o->getSize());
@@ -35,7 +35,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase {
             'MIME-Version' => 'Mime Version',
         ];
 
-        $o = new Object;
+        $o = new BaseObject;
         foreach ($headers as $k => $v) {
             $o->setFromHeader($k, $v);
         }
@@ -52,7 +52,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase {
     /** @test **/
     public function it_marks_preferred_objects()
     {
-        $o = new Object;
+        $o = new BaseObject;
         $this->assertFalse($o->isPreferred());
         $o->setPreferred(1);
         $this->assertTrue($o->isPreferred());
@@ -66,7 +66,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase {
         $e->setCode(1234);
         $e->setMessage('Test Error Message');
 
-        $o = new Object;
+        $o = new BaseObject;
         $this->assertFalse($o->isError());
         $o->setError($e);
         $this->assertTrue($o->isError());

--- a/tests/Parsers/GetObject/MultipleTest.php
+++ b/tests/Parsers/GetObject/MultipleTest.php
@@ -40,7 +40,7 @@ class MultipleTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(5, $collection->count());
 
-        /** @var PHRETS\Models\Object $obj */
+        /** @var PHRETS\Models\BaseObject $obj */
         $obj = $collection->first();
         $this->assertSame('Exterior Main View', $obj->getContentDescription());
         $this->assertSame('http://url1.jpg', $obj->getLocation());
@@ -88,7 +88,7 @@ class MultipleTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(5, $collection->count());
 
-        /** @var PHRETS\Models\Object $obj */
+        /** @var PHRETS\Models\BaseObject $obj */
         $obj = $collection->first();
         $this->assertSame('Exterior Main View', $obj->getContentDescription());
         $this->assertSame('http://url1.jpg', $obj->getLocation());


### PR DESCRIPTION
PHP7.2 no longer accepts class names to be `Object`: https://github.com/php/php-src/blob/php-7.2.0RC6/UPGRADING#L44

@mariano, can you take a look at this as well? Thanks!