### PR TITLE
Improve performance

### DIFF
--- a/src/Interpreters/GetObject.php
+++ b/src/Interpreters/GetObject.php
@@ -30,9 +30,9 @@ class GetObject
     protected static function split($value, $dash_ranges = true)
     {
         if (!is_array($value)) {
-            if (preg_match('/\:/', $value)) {
+            if (stripos($value, ':') !== false) {
                 $value = array_map('trim', explode(':', $value));
-            } elseif (preg_match('/\,/', $value)) {
+            } elseif (stripos($value, ',') !== false) {
                 $value = array_map('trim', explode(',', $value));
             } elseif ($dash_ranges and preg_match('/(\d+)\-(\d+)/', $value, $matches)) {
                 $value = range($matches[1], $matches[2]);

--- a/src/Models/Metadata/Base.php
+++ b/src/Models/Metadata/Base.php
@@ -33,17 +33,20 @@ abstract class Base implements \ArrayAccess
      */
     public function __call($name, $args = [])
     {
-        if (preg_match('/^set/', strtolower($name))) {
+        $name = strtolower($name);
+        $action = substr($name, 0, 3);
+
+        if ($action === 'set') {
             foreach (array_merge($this->getXmlElements(), $this->getXmlAttributes()) as $attr) {
-                if (strtolower('set' . $attr) == strtolower($name)) {
+                if (strtolower('set' . $attr) == $name) {
                     $this->values[$attr] = $args[0];
                     break;
                 }
             }
             return $this;
-        } elseif (preg_match('/^get/', strtolower($name))) {
+        } elseif ($action === 'get') {
             foreach (array_merge($this->getXmlElements(), $this->getXmlAttributes()) as $attr) {
-                if (strtolower('get' . $attr) == strtolower($name)) {
+                if (strtolower('get' . $attr) == $name) {
                     return \array_get($this->values, $attr);
                 }
             }

--- a/src/Parsers/Search/OneX.php
+++ b/src/Parsers/Search/OneX.php
@@ -83,15 +83,20 @@ class OneX
     protected function getColumnNames(Session $rets, &$xml, $parameters)
     {
         $delim = $this->getDelimiter($rets, $xml, $parameters);
+        $delimLength = strlen($delim);
 
         // break out and track the column names in the response
         $column_names = "{$xml->COLUMNS[0]}";
 
-        // take out the first delimiter
-        $column_names = preg_replace("/^{$delim}/", "", $column_names);
+        // Take out the first delimiter
+        if (substr($column_names, 0, $delimLength) == $delim) {
+            $column_names = substr($column_names, $delimLength);
+        }
 
-        // take out the last delimiter
-        $column_names = preg_replace("/{$delim}\$/", "", $column_names);
+        // Take out the last delimiter
+        if (substr($column_names, -$delimLength) == $delim) {
+            $column_names = substr($column_names, 0, -$delimLength);
+        }
 
         // parse and return the rest
         return explode($delim, $column_names);
@@ -109,13 +114,21 @@ class OneX
     protected function parseRecordFromLine(Session $rets, &$xml, $parameters, &$line, Results $rs)
     {
         $delim = $this->getDelimiter($rets, $xml, $parameters);
+        $delimLength = strlen($delim);
 
         $r = new Record;
-        $field_data = (string)$line;
+        $field_data = (string) $line;
 
-        // split up DATA row on delimiter found earlier
-        $field_data = preg_replace("/^{$delim}/", "", $field_data);
-        $field_data = preg_replace("/{$delim}\$/", "", $field_data);
+        // Take out the first delimiter
+        if (substr($field_data, 0, $delimLength) == $delim) {
+            $field_data = substr($field_data, $delimLength);
+        }
+
+        // Take out the last delimiter
+        if (substr($field_data, -$delimLength) == $delim) {
+            $field_data = substr($field_data, 0, -$delimLength);
+        }
+
         $field_data = explode($delim, $field_data);
 
         foreach ($rs->getHeaders() as $key => $name) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -130,7 +130,7 @@ class Session
             ]
         );
 
-        if (preg_match('/multipart/', $response->getHeader('Content-Type'))) {
+        if (stripos($response->getHeader('Content-Type'), 'multipart') !== false) {
             $parser = $this->grab(Strategy::PARSER_OBJECT_MULTIPLE);
             $collection = $parser->parse($response);
         } else {
@@ -387,7 +387,7 @@ class Session
 
         $this->debug('Response: HTTP ' . $response->getStatusCode());
 
-        if (preg_match('/text\/xml/', $response->getHeader('Content-Type')) and $capability != 'GetObject') {
+        if (stripos($response->getHeader('Content-Type'), 'text/xml') !== false and $capability != 'GetObject') {
             $parser = $this->grab(Strategy::PARSER_XML);
             $xml = $parser->parse($response);
 


### PR DESCRIPTION
Based on @TheDigitalOrchard PR (#50) I just replaced some `preg_match` calls with `stripos`.

Removed `preg_replace` in favor of `substr`.