### PR TITLE
Trim body before instantiating the XML element.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -21,7 +21,12 @@ class Response
 
 	public function xml()
 	{
-		return new \SimpleXMLElement((string) $this->response->getBody());
+		$body = (string) $this->response->getBody();
+
+		// Remove any carriage return / newline in XML response.
+		$body = trim($body);
+
+		return new \SimpleXMLElement($body);
 	}
 
 	public function __call($method, $args = [])
@@ -32,7 +37,7 @@ class Response
 	public function getHeader($name)
 	{
 		$headers = $this->response->getHeader($name);
-		
+
 		if ($headers) {
 			return implode('; ', $headers);
 		} else {

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -1,0 +1,26 @@
+<?php
+
+class ResponseTest extends PHPUnit_Framework_TestCase {
+
+    /** @test **/
+    public function it_creates_valid_xml()
+    {
+        $body = "<?xml version='1.0' encoding='UTF-8'?><guestbook><guest><fname>First Name</fname><lname>Last Name</lname></guest></guestbook>";
+        $guzzleResponse = new GuzzleHttp\Psr7\Response(200, ['X-Foo' => 'Bar'], $body);
+
+        $response = new PHRETS\Http\Response($guzzleResponse);
+
+        $this->assertEquals(1, $response->xml()->count());
+    }
+
+    /** @test **/
+    public function it_creates_valid_xml_with_new_lines()
+    {
+        $body = "\n\n\r<?xml version='1.0' encoding='UTF-8'?><guestbook><guest><fname>First Name</fname><lname>Last Name</lname></guest></guestbook>\r\n\n";
+        $guzzleResponse = new GuzzleHttp\Psr7\Response(200, ['X-Foo' => 'Bar'], $body);
+
+        $response = new PHRETS\Http\Response($guzzleResponse);
+
+        $this->assertEquals(1, $response->xml()->count());
+    }
+}


### PR DESCRIPTION
Due to finding some invalid XML due to carriage returns in the payload.

This PR continues the work of @fbstim on #144.