### PR TITLE
POST request fixup

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -335,6 +335,7 @@ class Session
             if ($this->configuration->readOption('use_post_method')) {
                 $this->debug('Using POST method per use_post_method option');
                 $query = (array_key_exists('query', $options)) ? $options['query'] : null;
+                unset($options['query']);
                 $response = $this->client->request('POST', $url, array_merge($options, ['form_params' => $query]));
             } else {
                 $response = $this->client->request('GET', $url, $options);


### PR DESCRIPTION
If `$options['query']` is passed into `client->request` it's represented as POST body along with URL parameters. In my case list of ID exits URL max length.