### PR TITLE
Add the ability to set the GuzzleHttp\Client instance on the PHRETS\Session

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "troydavisson/phrets",
   "type": "library",
   "license": "MIT",
+  "version": "2.5.1",
   "description": "RETS library in PHP",
   "keywords": [
     "rets",

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,6 +1,5 @@
 <?php namespace PHRETS;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\ClientException;
@@ -16,6 +15,7 @@ use PHRETS\Interpreters\Search;
 use PHRETS\Models\Bulletin;
 use PHRETS\Strategies\Strategy;
 use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 
 class Session
 {
@@ -41,7 +41,7 @@ class Session
         $defaults = [];
 
         // start up our Guzzle HTTP client
-        $this->client = PHRETSClient::make($defaults);
+        $this->setClient(PHRETSClient::make($defaults));
 
         $this->cookie_jar = new CookieJar;
 
@@ -501,11 +501,19 @@ class Session
     }
 
     /**
-     * @return Client
+     * @return GuzzleClientInterface
      */
     public function getClient()
     {
         return $this->client;
+    }
+
+    /**
+     * @param GuzzleClientInterface $client [description]
+     */
+    public function setClient(GuzzleClientInterface $client)
+    {
+        $this->client = $client;
     }
 
     /**


### PR DESCRIPTION
We use PHRETS to connect to and download data from MRIS/BrightMLS.

We have a use case that requires our application, in a single runtime, to connect to more than one server. As is, this is impossible because the `PHRETS\Session` calls `PHRETSClient` to manage a singleton instance of `GuzzleHttp\Client`. This makes it impossible to authenticate more than one RETS session per runtime, which we need to be able to do.

This is solved by adding a mutator to `PHRETS\Session`, allowing for our application to set the instance of `GuzzleHttp\Client` at the time the session object is created. 

All of your unit tests are passing.