### PR TITLE
Xml parse exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
   ],
   "require": {
     "php": ">=5.5.0",
+    "ext-iconv": "*",
+    "ext-mbstring": "*",
     "guzzlehttp/guzzle": ">=6.0",
     "illuminate/container": ">=4.2.0",
     "illuminate/support": ">=4.2.0",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -259,7 +259,7 @@ class Configuration
      */
     public function setHttpAuthenticationMethod($auth_method)
     {
-        if ($auth_method && !in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
+        if (!in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
             throw new \InvalidArgumentException("Given authentication method is invalid.  Must be 'basic' or 'digest'");
         }
         $this->http_authentication = $auth_method;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -259,7 +259,7 @@ class Configuration
      */
     public function setHttpAuthenticationMethod($auth_method)
     {
-        if (!in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
+        if ($auth_method && !in_array($auth_method, [self::AUTH_BASIC, self::AUTH_DIGEST])) {
             throw new \InvalidArgumentException("Given authentication method is invalid.  Must be 'basic' or 'digest'");
         }
         $this->http_authentication = $auth_method;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,6 +20,7 @@ class Configuration
     protected $http_authentication = 'digest';
     /** @var \PHRETS\Strategies\Strategy */
     protected $strategy;
+    protected $sessionTempDir = null;
     protected $options = [];
 
     public function __construct()
@@ -133,6 +134,24 @@ class Configuration
     {
         $this->username = $username;
         return $this;
+    }
+
+    /**
+     * @param string $username
+     * @return $this
+     */
+    public function setSessionTempDir($sessionTempDir)
+    {
+        $this->sessionTempdDir = $sessionTempDir;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSessionTempDir()
+    {
+        return $this->sessionTempDir;
     }
 
     /**

--- a/src/Parsers/XML.php
+++ b/src/Parsers/XML.php
@@ -11,6 +11,20 @@ class XML
             $string = $string->getBody()->__toString();
         }
 
-        return new \SimpleXMLElement((string) $string);
+        $string = (string) $string;
+
+        /**
+         * Some rets provider(s) return invalid XML data.
+         * Here we make sure the returned data are UTF-8 valid chars.
+         * I've seen so far:
+         *  - windows carriage return (^M at the end of each lines)
+         *  - trade mark sign not converted to &trade; and I guess we can have other sigh like this.
+         *
+         * NOTE:
+         *  //IGNORE will discard the invalid UTF-8 chars.
+         */
+        $string = iconv(mb_detect_encoding($string), 'UTF-8//IGNORE', $string);
+
+        return new \SimpleXMLElement($string);
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -339,6 +339,8 @@ class Session
 
         $response = new \PHRETS\Http\Response($response);
 
+        $this->removeSessionCookieFile($options);
+
         $this->last_response = $response;
 
         if ($response->getHeader('Set-Cookie')) {
@@ -349,7 +351,7 @@ class Session
                 }
             }
         }
-        
+
         if (preg_match('/text\/xml/', $response->getHeader('Content-Type')) and $capability != 'GetObject') {
             $parser = $this->grab(Strategy::PARSER_XML);
             $xml = $parser->parse($response);
@@ -481,7 +483,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => tempnam($this->configuration->getSessionTempDir(), 'phrets') ]
         ];
 
         // disable following 'Location' header (redirects) automatically
@@ -490,6 +492,21 @@ class Session
         }
 
         return $defaults;
+    }
+
+    /**
+     * If the session cookie file have beend created, we will remove it.
+     *
+     * @param array $options Assoc array that came from the method getDefaultOptions.
+     *
+     * @return void
+     */
+    private function removeSessionCookieFile(array $options)
+    {
+        $tmpFile = $options['curl'][CURLOPT_COOKIEFILE];
+        if (file_exists($tmpFile)) {
+            unlink($tmpFile);
+        }
     }
 
     public function setParser($parser_name, $parser_object)


### PR DESCRIPTION
An old closed issue still valid and I've figured out the problem.
here is the issue I'm talking about:  https://github.com/troydavisson/PHRETS/issues/73

WARNING:
- I've fix it with 2 required php extensions.  iconv and mbstring  so if you release this fix I think we should have a major release to make sure people using composer will not get problems if they do not have those extensions installed.

The issue is releated to the fact some of the providers do not return the data properly and the xml is not valid.

1- the Windows/Linux issue is probably related to the ^M that appear at the end of each lines (Windows char). I've got this crap from the mlslistings rets server response.
2- I've also receive non UTF-8 char into the xml from the mlslisting server. ex: The copy right sigh that they didn't html entity.

I've test this fix with those rets servers: rebny, mlspin, gamls, fmls and mlslistings