### PR TITLE
Fix issue #172 with tempnam() throwing an Exception.

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -543,7 +543,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => tempnam(sys_get_temp_dir(), 'phrets') ]
         ];
 
         // disable following 'Location' header (redirects) automatically


### PR DESCRIPTION
I have a Homestead server setup on my Windows PC for Laravel development. 

When I run a command in my local CLI that calls PHRETS I get an error exception because Window's temporary directory is not "/tmp."

Using `sys_get_temp_dir()` will return the correct path for PHP's temporary file store for the current environment. On Linux it will still be `/tmp`.