### PR TITLE
fix use_post_method

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -325,19 +325,20 @@ class Session
 
         $this->debug("Sending HTTP Request for {$url} ({$capability})", $options);
 
-        if (array_key_exists('query', $options)) {
-            $this->last_request_url = $url . '?' . \http_build_query($options['query']);
-        } else {
-            $this->last_request_url = $url;
-        }
-
         try {
             /** @var ResponseInterface $response */
             if ($this->configuration->readOption('use_post_method')) {
                 $this->debug('Using POST method per use_post_method option');
                 $query = (array_key_exists('query', $options)) ? $options['query'] : null;
+                $options['query'] = null;
                 $response = $this->client->request('POST', $url, array_merge($options, ['form_params' => $query]));
             } else {
+                if (array_key_exists('query', $options)) {
+                    $this->last_request_url = $url . '?' . \http_build_query($options['query']);
+                } else {
+                    $this->last_request_url = $url;
+                }
+
                 $response = $this->client->request('GET', $url, $options);
             }
         } catch (ClientException $e) {


### PR DESCRIPTION
Fixes handling of use_post_method option.
In current state it sends query params via POST and also via GET, what is probably not what was this option intended for.