### PR TITLE
replace deprecated/removed array_get with Arr::get 

### DIFF
--- a/src/Models/Bulletin.php
+++ b/src/Models/Bulletin.php
@@ -1,5 +1,7 @@
 <?php namespace PHRETS\Models;
 
+use Illuminate\Support\Arr;
+
 class Bulletin
 {
     protected $body = null;
@@ -45,7 +47,7 @@ class Bulletin
      */
     public function getDetail($name)
     {
-        return array_get($this->details, strtoupper($name));
+        return Arr::get($this->details, strtoupper($name));
     }
 
     /**

--- a/src/Models/Metadata/Base.php
+++ b/src/Models/Metadata/Base.php
@@ -1,5 +1,7 @@
 <?php namespace PHRETS\Models\Metadata;
 
+use Illuminate\Support\Arr;
+
 abstract class Base implements \ArrayAccess
 {
     /** @var \PHRETS\Session */
@@ -47,7 +49,7 @@ abstract class Base implements \ArrayAccess
         } elseif ($action === 'get') {
             foreach (array_merge($this->getXmlElements(), $this->getXmlAttributes()) as $attr) {
                 if (strtolower('get' . $attr) == $name) {
-                    return \array_get($this->values, $attr);
+                    return Arr::get($this->values, $attr);
                 }
             }
             return null;

--- a/src/Models/Metadata/Base.php
+++ b/src/Models/Metadata/Base.php
@@ -109,7 +109,7 @@ abstract class Base implements \ArrayAccess
     {
         foreach (array_merge($this->getXmlElements(), $this->getXmlAttributes()) as $attr) {
             if (strtolower($attr) == strtolower($offset)) {
-                return \array_get($this->values, $attr);
+                return Arr::get($this->values, $attr);
             }
         }
         return null;

--- a/src/Parsers/GetObject/Single.php
+++ b/src/Parsers/GetObject/Single.php
@@ -1,5 +1,6 @@
 <?php namespace PHRETS\Parsers\GetObject;
 
+use Illuminate\Support\Arr;
 use PHRETS\Http\Response;
 use PHRETS\Models\BaseObject;
 use PHRETS\Models\RETSError;
@@ -12,14 +13,14 @@ class Single
 
         $obj = new BaseObject;
         $obj->setContent(($response->getBody()) ? $response->getBody()->__toString() : null);
-        $obj->setContentDescription(\array_get($headers, 'Content-Description', [null])[0]);
-        $obj->setContentSubDescription(\array_get($headers, 'Content-Sub-Description', [null])[0]);
-        $obj->setContentId(\array_get($headers, 'Content-ID', [null])[0]);
-        $obj->setObjectId(\array_get($headers, 'Object-ID', [null])[0]);
-        $obj->setContentType(\array_get($headers, 'Content-Type', [null])[0]);
-        $obj->setLocation(\array_get($headers, 'Location', [null])[0]);
-        $obj->setMimeVersion(\array_get($headers, 'MIME-Version', [null])[0]);
-        $obj->setPreferred(\array_get($headers, 'Preferred', [null])[0]);
+        $obj->setContentDescription(Arr::get($headers, 'Content-Description', [null])[0]);
+        $obj->setContentSubDescription(Arr::get($headers, 'Content-Sub-Description', [null])[0]);
+        $obj->setContentId(Arr::get($headers, 'Content-ID', [null])[0]);
+        $obj->setObjectId(Arr::get($headers, 'Object-ID', [null])[0]);
+        $obj->setContentType(Arr::get($headers, 'Content-Type', [null])[0]);
+        $obj->setLocation(Arr::get($headers, 'Location', [null])[0]);
+        $obj->setMimeVersion(Arr::get($headers, 'MIME-Version', [null])[0]);
+        $obj->setPreferred(Arr::get($headers, 'Preferred', [null])[0]);
 
         if ($this->isError($response)) {
             $xml = $response->xml();
@@ -45,7 +46,7 @@ class Single
             return true;
         }
 
-        $content_type = \array_get($response->getHeaders(), 'Content-Type', [null])[0];
+        $content_type = Arr::get($response->getHeaders(), 'Content-Type', [null])[0];
         if ($content_type and strpos($content_type, 'xml') !== false) {
             $xml = $response->xml();
 


### PR DESCRIPTION
array_get was previously marked as @deprecated and, as of the [release of `6.0.0` on Sept 3, 2019](https://packagist.org/packages/illuminate/support), has been fully removed.
This uses Arr::get instead.

(this PR replaces https://github.com/troydavisson/PHRETS/pull/245)