### PR TITLE
resolves issued #172

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,7 +20,10 @@ class Configuration
     protected $http_authentication = 'digest';
     /** @var \PHRETS\Strategies\Strategy */
     protected $strategy;
-    protected $options = [];
+    protected $options = [
+        'suppress_tmp_warn' => true,
+        'tmp_path'          => '/tmp'
+    ];
 
     public function __construct()
     {

--- a/src/Session.php
+++ b/src/Session.php
@@ -534,6 +534,12 @@ class Session
      */
     public function getDefaultOptions()
     {
+        if ($this->configuration->readOption('suppress_tmp_warn')) {
+            $curl = @tempnam($this->configuration->readOption('tmp_path'), 'phrets');
+        } else {
+            $curl = tempnam($this->configuration->readOption('tmp_path'), 'phrets');
+        }
+
         $defaults = [
             'auth' => [
                 $this->configuration->getUsername(),
@@ -546,7 +552,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => $curl ]
         ];
 
         // disable following 'Location' header (redirects) automatically


### PR DESCRIPTION
Due to https://bugs.php.net/bug.php?id=69489, PHP 7.1 and above  raises a notice. This PR provides two alternatives.

1. Using a flag to suppress the error. (Current default behavior)
```php
$config->setOption('suppress_tmp_warn', true);
```
2. Explicitly setting a path for unique file creation.
```php
$config->setOption('tmp_path', 'C:\Users\{UserName}\AppData\Local\Temp');
``` 