### PR TITLE
dynamic tmp dir

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -546,7 +546,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => tempnam(sys_get_temp_dir(), 'phrets') ]
         ];
 
         // disable following 'Location' header (redirects) automatically


### PR DESCRIPTION
Instead of hard-coding `/tmp`, call `sys_get_temp_dir()` to get the path of the current system temp directory.