### PR TITLE
add Logout() method

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -546,7 +546,7 @@ class Session
                 'Accept-Encoding' => 'gzip',
                 'Accept' => '*/*',
             ],
-            'curl' => [ CURLOPT_COOKIEFILE => tempnam('/tmp', 'phrets') ]
+            'curl' => [ CURLOPT_COOKIEFILE => tempnam(sys_get_temp_dir(), 'phrets') ]
         ];
 
         // disable following 'Location' header (redirects) automatically

--- a/src/Session.php
+++ b/src/Session.php
@@ -293,10 +293,19 @@ class Session
      * @return bool
      * @throws Exceptions\CapabilityUnavailable
      */
-    public function Disconnect()
+    public function Logout()
     {
         $response = $this->request('Logout');
         return true;
+    }
+
+    /**
+     * @return bool
+     * @throws Exceptions\CapabilityUnavailable
+     */
+    public function Disconnect()
+    {
+        return $this->Logout();
     }
 
     /**


### PR DESCRIPTION
This has hung me up more than once... there is a `Login()` method to match the transaction by that name, but to log out one must call `Disconnect()` instead of `Logout()`, which seems odd.

This pull-request adds the `Logout()` method, and makes `Disconnect()` an alias to it for compatibility.

If I misunderstood why the API was done this way, please kindly explain.
