### PR TITLE
add Logout method to match RETS spec

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -293,10 +293,19 @@ class Session
      * @return bool
      * @throws Exceptions\CapabilityUnavailable
      */
+    public function Logout()
+    {
+        $this->request('Logout');
+        return true;
+    }
+
+    /**
+     * @return bool
+     * @throws Exceptions\CapabilityUnavailable
+     */
     public function Disconnect()
     {
-        $response = $this->request('Logout');
-        return true;
+        return $this->Logout();
     }
 
     /**


### PR DESCRIPTION
I always found it unusual that one must call `Disconnect()` to execute the `Logout` transaction. This PR adds a `Logout()` method to match the RETS spec, similar to the existing `Login()` method. The `Disconnect()` method remains as an alias.

Also, there's no need to capture the result of the Logout method into a variable, since nothing is done with it, so this small change was included.

If I am misunderstanding why the API was done this way, please enlighten me.
