### PR TITLE
Feature: Add support for the X-Content-Label header

### DIFF
--- a/src/Models/BaseObject.php
+++ b/src/Models/BaseObject.php
@@ -7,6 +7,7 @@ class BaseObject
     protected $object_id;
     protected $mime_version;
     protected $location;
+    protected $content_label;
     protected $content_description;
     protected $content_sub_description;
     protected $content;
@@ -28,6 +29,24 @@ class BaseObject
     public function setContent($content)
     {
         $this->content = $content;
+        return $this;
+    }
+
+    /**
+     * @param mixed $content_description
+     * @return $this
+     */
+    public function getContentLabel()
+    {
+        return $this->content_label;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function setContentLabel($label)
+    {
+        $this->content_label = $label;
         return $this;
     }
 
@@ -164,6 +183,7 @@ class BaseObject
     public function setFromHeader($name, $value)
     {
         $headers = [
+            'X-Content-Label' => 'ContentLabel',
             'Content-Description' => 'ContentDescription',
             'Content-Sub-Description' => 'ContentSubDescription',
             'Content-ID' => 'ContentId',

--- a/src/Parsers/GetObject/Single.php
+++ b/src/Parsers/GetObject/Single.php
@@ -10,6 +10,7 @@ class Single
     {
         $obj = new BaseObject;
         $obj->setContent(($response->getBody()) ? $response->getBody()->__toString() : null);
+        $obj->setContentLabel($response->getHeader('X-Content-Label'));
         $obj->setContentDescription($response->getHeader('Content-Description'));
         $obj->setContentSubDescription($response->getHeader('Content-Sub-Description'));
         $obj->setContentId($response->getHeader('Content-ID'));


### PR DESCRIPTION
Adds support for the `X-Content-Label` header, in the RETS server (Paragon) a client is using this appears to be used as the label for listing photos.