### PR TITLE
fix the deprecated GuzzleHttp parse_response method

### DIFF
--- a/src/Parsers/GetObject/Multiple.php
+++ b/src/Parsers/GetObject/Multiple.php
@@ -49,7 +49,7 @@ class Multiple
         // go through each part of the multipart message
         foreach ($multi_parts as $part) {
             // get Guzzle to parse this multipart section as if it's a whole HTTP message
-            $parts = \GuzzleHttp\Psr7\parse_response("HTTP/1.1 200 OK\r\n" . $part . "\r\n");
+            $parts = \GuzzleHttp\Psr7\Message::parseResponse("HTTP/1.1 200 OK\r\n" . $part . "\r\n");
 
             // now throw this single faked message through the Single GetObject response parser
             $single = new PHRETSResponse(new Response($parts->getStatusCode(), $parts->getHeaders(), (string)$parts->getBody()));


### PR DESCRIPTION
parse_response has been deprecated and replaced with Message::parseResponse.

